### PR TITLE
Fix building on ArchLinux

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,8 @@
+@SET_MAKE@
+
+AUTOMAKE_OPTIONS = subdir-objects
+ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
+
 SUBDIRS =	\
 	plugin  \
 	po

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,33 +1,13 @@
 #!/bin/sh
-#
-# Copyright (c) 2002-2012 The Xfce development team. All rights reserved.
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of the GNU General Public License as published by the Free
-# Software Foundation; either version 3 of the License, or (at your option)
-# any later version.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
-# more details.
-#
-# You should have received a copy of the GNU Lesser General Public
-# License along with this library; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
-#
-# Written for Xfce by Benedikt Meurer <benny@xfce.org>.
-#
 
-(type xdt-autogen) >/dev/null 2>&1 || {
+type xdt-autogen >/dev/null 2>&1 || {
   cat >&2 <<EOF
 autogen.sh: You don't seem to have the Xfce development tools installed on
             your system, which are required to build this software.
             Please install the xfce4-dev-tools package first, it is available
-            from http://www.xfce.org/.
+            from your distribution or https://www.xfce.org/.
 EOF
   exit 1
 }
 
-XDT_AUTOGEN_REQUIRED_VERSION="4.9.1" \
-exec xdt-autogen $@
+XDT_AUTOGEN_REQUIRED_VERSION="4.17.0" exec xdt-autogen "$@"

--- a/configure.ac.in
+++ b/configure.ac.in
@@ -25,7 +25,7 @@ AC_COPYRIGHT([Copyright (C) 2021
 AC_INIT([xfce4-i3-window-title-plugin], [plugin_version], [https://github.com/carmelopellegrino/xfce4-i3-window-title-plugin/issues], [xfce4-i3-window-title-plugin])
 AC_PREREQ([2.69])
 AC_REVISION([xdt_version_build])
-AC_CONFIG_MACRO_DIRS([m4])
+AC_CONFIG_MACRO_DIRS([m4 /usr/share/gettext/m4/])
 AC_DEFINE([VERSION_FULL], [PACKAGE_VERSION], [Alias for VERSION and PACKAGE_VERSION for meson compatibility])
 COPYRIGHT_YEAR=copyright_year()
 AC_DEFINE_UNQUOTED([COPYRIGHT_YEAR], ["$COPYRIGHT_YEAR"], [Copyright year])

--- a/configure.ac.in
+++ b/configure.ac.in
@@ -8,6 +8,7 @@ dnl
 dnl ***************************
 dnl *** Version information ***
 dnl ***************************
+m4_define([copyright_year], [2025])
 m4_define([plugin_version_major], [0])
 m4_define([plugin_version_minor], [0])
 m4_define([plugin_version_micro], [0])
@@ -19,17 +20,27 @@ m4_define([plugin_version], [plugin_version_major().plugin_version_minor().plugi
 dnl ***************************
 dnl *** Initialize autoconf ***
 dnl ***************************
-AC_COPYRIGHT([Copyright (C) 2014
+AC_COPYRIGHT([Copyright (C) 2021
         The Xfce development team. All rights reserved.])
 AC_INIT([xfce4-i3-window-title-plugin], [plugin_version], [https://github.com/carmelopellegrino/xfce4-i3-window-title-plugin/issues], [xfce4-i3-window-title-plugin])
-AC_PREREQ([2.50])
-AC_REVISION([xfce4_panel_version_build])
+AC_PREREQ([2.69])
+AC_REVISION([xdt_version_build])
+AC_CONFIG_MACRO_DIRS([m4])
+AC_DEFINE([VERSION_FULL], [PACKAGE_VERSION], [Alias for VERSION and PACKAGE_VERSION for meson compatibility])
+COPYRIGHT_YEAR=copyright_year()
+AC_DEFINE_UNQUOTED([COPYRIGHT_YEAR], ["$COPYRIGHT_YEAR"], [Copyright year])
+AC_SUBST([COPYRIGHT_YEAR])
+
+dnl *******************************
+dnl *** Check for UNIX variants ***
+dnl *******************************
+AC_USE_SYSTEM_EXTENSIONS()
 
 dnl ***************************
 dnl *** Initialize automake ***
 dnl ***************************
-AM_INIT_AUTOMAKE([1.8 no-dist-gzip dist-bzip2 tar-ustar])
-AM_CONFIG_HEADER([config.h])
+AM_INIT_AUTOMAKE([1.15 no-dist-gzip dist-bzip2 tar-ustar foreign])
+AC_CONFIG_HEADERS([config.h])
 AM_MAINTAINER_MODE()
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
@@ -39,25 +50,19 @@ dnl **************************
 LT_PREREQ([2.2.6])
 LT_INIT([disable-static])
 
-dnl *******************************
-dnl *** Check for UNIX variants ***
-dnl *******************************
-AC_AIX()
-AC_ISC_POSIX()
-
 dnl ********************************
 dnl *** Check for basic programs ***
 dnl ********************************
 AC_PROG_CC()
-AM_PROG_CC_C_O()
-AC_PROG_LD()
+AC_PROG_CC_C_O()
+#AC_PROG_LD()
 AC_PROG_INSTALL()
-AC_PROG_INTLTOOL()
+IT_PROG_INTLTOOL([0.35.0])
 
 dnl **********************************
 dnl *** Check for standard headers ***
 dnl **********************************
-AC_HEADER_STDC()
+AC_INCLUDES_DEFAULT()
 AC_CHECK_HEADERS([stdlib.h unistd.h locale.h stdio.h errno.h time.h string.h \
                   math.h sys/types.h sys/wait.h memory.h signal.h sys/prctl.h \
                   libintl.h])
@@ -76,8 +81,11 @@ XDT_CHECK_LIBX11_REQUIRE()
 dnl ***********************************
 dnl *** Check for required packages ***
 dnl ***********************************
-XDT_CHECK_PACKAGE([LIBXFCE4UI], [libxfce4ui-2], [4.12.0])
-XDT_CHECK_PACKAGE([LIBXFCE4PANEL], [libxfce4panel-2.0], [4.12.0])
+XDT_CHECK_PACKAGE([GLIB], [glib-2.0], [2.66.0])
+XDT_CHECK_PACKAGE([GTK], [gtk+-3.0], [3.24.0])
+XDT_CHECK_PACKAGE([LIBXFCE4UI], [libxfce4ui-2], [4.16.0])
+XDT_CHECK_PACKAGE([LIBXFCE4UTIL], [libxfce4util-1.0], [4.16.0])
+XDT_CHECK_PACKAGE([LIBXFCE4PANEL], [libxfce4panel-2.0], [4.16.0])
 XDT_CHECK_PACKAGE([LIBI3IPCGLIB], [i3ipc-glib-1.0], [0.5])
 
 dnl ***********************************
@@ -98,11 +106,12 @@ AC_MSG_CHECKING([PLATFORM_LDFLAGS])
 AC_MSG_RESULT([$PLATFORM_LDFLAGS])
 AC_SUBST([PLATFORM_LDFLAGS])
 
-AC_OUTPUT([
+AC_CONFIG_FILES([
 Makefile
 plugin/Makefile
 po/Makefile.in
 ])
+AC_OUTPUT
 
 dnl ***************************
 dnl *** Print configuration ***

--- a/plugin/Makefile.am
+++ b/plugin/Makefile.am
@@ -18,6 +18,8 @@ plugindir = \
 libi3windowtitle_la_SOURCES = i3wm-window-title.h i3wm-window-title.c
 
 libi3windowtitle_la_CFLAGS = \
+	$(GLIB_CFLAGS) \
+	$(GTK_CFLAGS) \
 	$(LIBXFCE4UTIL_CFLAGS) \
 	$(LIBXFCE4UI_CFLAGS) \
 	$(LIBXFCE4PANEL_CFLAGS) \


### PR DESCRIPTION
ArchLinux now installs the `nls.m4` file in `/usr/share/gettext/m4/` rather than in the previous `/usr/share/aclocal/`.